### PR TITLE
Use non-zero exit code when problems are found

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,6 +8,6 @@ const { run } = require('../index');
 
 let rootDir = pkgDir.sync();
 
-run(rootDir).catch(error => {
+process.exitCode = run(rootDir).catch(error => {
   console.error(chalk.red(error.stack));
 });

--- a/index.js
+++ b/index.js
@@ -70,6 +70,10 @@ async function run(rootDir, options = {}) {
       log(`   - ${key} ${chalk.dim(`(used in ${generateFileList(files)})`)}`);
     }
   }
+
+  let totalErrors = missingTranslations.size + unusedTranslations.size;
+
+  return totalErrors > 0 ? 1 : 0;
 }
 
 function readConfig(cwd) {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ let fixtures = fs.readdirSync(`${__dirname}/fixtures/`);
 
 describe('Test Fixtures', () => {
   let output;
+  let fixturesWithErrors = ['emblem', 'missing-translations', 'unused-translations'];
 
   beforeEach(() => {
     output = '';
@@ -16,7 +17,11 @@ describe('Test Fixtures', () => {
 
   for (let fixture of fixtures) {
     test(fixture, async () => {
-      await run(`${__dirname}/fixtures/${fixture}`, { log, color: false });
+      let returnValue = await run(`${__dirname}/fixtures/${fixture}`, { log, color: false });
+
+      let expectedReturnValue = fixturesWithErrors.includes(fixture) ? 1 : 0;
+
+      expect(returnValue).toEqual(expectedReturnValue);
       expect(output).toMatchSnapshot();
     });
   }


### PR DESCRIPTION
Adds a return value from `run` which is the appropriate exit code based on the result of the run.

We then set `process.exitCode` to that value and the CLI will exit with that value when the script completes.

Tests were also modified to expect the correct return value.

Closes #7 