### PR TITLE
Add `--fix` CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ To prevent that from happening you can configure a `whitelist`, which accepts an
 array of regular expressions that will be checked when looking for unused
 translations.
 
+### `--fix`
+If your application has a lot of unused translations you can run the command with
+the `--fix` to remove them. Remember to double check your translations as dynamic
+translations need to be whitelisted or they will be removed!
 
 Caveats
 ------------------------------------------------------------------------------

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -12,6 +12,22 @@ exports[`Test Fixtures decorators 1`] = `
 "
 `;
 
+exports[`Test Fixtures decorators 2`] = `Map {}`;
+
+exports[`Test Fixtures embedded-conditionals 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ 👏  No missing translations were found!
+"
+`;
+
+exports[`Test Fixtures embedded-conditionals 2`] = `Map {}`;
+
 exports[`Test Fixtures emblem 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...
@@ -25,6 +41,8 @@ exports[`Test Fixtures emblem 1`] = `
    - emblem-translation (used in app/templates/application.emblem)
 "
 `;
+
+exports[`Test Fixtures emblem 2`] = `Map {}`;
 
 exports[`Test Fixtures missing-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
@@ -41,6 +59,8 @@ exports[`Test Fixtures missing-translations 1`] = `
 "
 `;
 
+exports[`Test Fixtures missing-translations 2`] = `Map {}`;
+
 exports[`Test Fixtures no-issues 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...
@@ -53,6 +73,76 @@ exports[`Test Fixtures no-issues 1`] = `
 "
 `;
 
+exports[`Test Fixtures no-issues 2`] = `Map {}`;
+
+exports[`Test Fixtures remove-unused-translations 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ ⚠️   Found 3 unused translations!
+
+   - foo (used in de.json and en.json)
+   - extra (used in de.json)
+   - foo.bar.unnested (used in de.json and en.json)
+
+ 👏  No missing translations were found!
+
+ 👏 All unused translations were removed
+"
+`;
+
+exports[`Test Fixtures remove-unused-translations 2`] = `
+Map {
+  "translations/de.json" => "{
+  \\"hbs-translation\\": \\"Lenkstage\\",
+  \\"js-translation\\": \\"Affentheater\\"
+}",
+  "translations/en.json" => "{
+  \\"hbs-translation\\": \\"HBS!\\",
+  \\"js-translation\\": \\"JS!\\"
+}",
+}
+`;
+
+exports[`Test Fixtures remove-unused-translations-nested 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ ⚠️   Found 3 unused translations!
+
+   - foo (used in de.json and en.json)
+   - extra (used in de.json)
+   - parent.child.unusedKey (used in de.json and en.json)
+
+ 👏  No missing translations were found!
+
+ 👏 All unused translations were removed
+"
+`;
+
+exports[`Test Fixtures remove-unused-translations-nested 2`] = `
+Map {
+  "translations/de.json" => "{
+  \\"hbs-translation\\": \\"Lenkstage\\",
+  \\"js-translation\\": \\"Affentheater\\",
+  \\"parent\\": {
+    \\"secondChild\\": \\"usedKey\\"
+  }
+}",
+  "translations/en.json" => "{
+  \\"hbs-translation\\": \\"HBS!\\",
+  \\"js-translation\\": \\"JS!\\",
+  \\"parent\\": {
+    \\"secondChild\\": \\"usedKey\\"
+  }
+}",
+}
+`;
+
 exports[`Test Fixtures unused-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...
@@ -60,6 +150,7 @@ exports[`Test Fixtures unused-translations 1`] = `
 [4/4] ⚙️   Checking for missing translations...
 
  ⚠️   Found 2 unused translations!
+     You can use --fix to remove all unused translations.
 
    - foo (used in de.json and en.json)
    - extra (used in de.json)
@@ -67,6 +158,8 @@ exports[`Test Fixtures unused-translations 1`] = `
  👏  No missing translations were found!
 "
 `;
+
+exports[`Test Fixtures unused-translations 2`] = `Map {}`;
 
 exports[`Test Fixtures yaml-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
@@ -80,14 +173,4 @@ exports[`Test Fixtures yaml-translations 1`] = `
 "
 `;
 
-exports[`Test Fixtures embedded-conditionals 1`] = `
-"[1/4] 🔍  Finding JS and HBS files...
-[2/4] 🔍  Searching for translations keys in JS and HBS files...
-[3/4] ⚙️   Checking for unused translations...
-[4/4] ⚙️   Checking for missing translations...
-
- 👏  No unused translations were found!
-
- 👏  No missing translations were found!
-"
-`;
+exports[`Test Fixtures yaml-translations 2`] = `Map {}`;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ const { run } = require('../index');
 
 let rootDir = pkgDir.sync();
 
-run(rootDir)
+run(rootDir, { fix: process.argv.includes('--fix') })
   .then(exitCode => {
     process.exitCode = exitCode;
   })

--- a/fixtures/remove-unused-translations-nested/app/controllers/application.js
+++ b/fixtures/remove-unused-translations-nested/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  foo: computed('intl.locale', function() {
+    return this.intl.t('js-translation');
+  }),
+});

--- a/fixtures/remove-unused-translations-nested/app/templates/application.hbs
+++ b/fixtures/remove-unused-translations-nested/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{t "hbs-translation"}}
+{{t "parent.secondChild"}}

--- a/fixtures/remove-unused-translations-nested/translations/de.json
+++ b/fixtures/remove-unused-translations-nested/translations/de.json
@@ -1,0 +1,12 @@
+{
+  "hbs-translation": "Lenkstage",
+  "js-translation": "Affentheater",
+  "foo": "BARR!",
+  "extra": "drei",
+  "parent": {
+    "child": {
+      "unusedKey": "unused Key",
+    },
+    "secondChild": "usedKey"
+  }
+}

--- a/fixtures/remove-unused-translations-nested/translations/en.json
+++ b/fixtures/remove-unused-translations-nested/translations/en.json
@@ -1,0 +1,11 @@
+{
+  "hbs-translation": "HBS!",
+  "js-translation": "JS!",
+  "foo": "bar",
+  "parent": {
+    "child": {
+      "unusedKey": "unused Key",
+    },
+    "secondChild": "usedKey"
+  }
+}

--- a/fixtures/remove-unused-translations/app/controllers/application.js
+++ b/fixtures/remove-unused-translations/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  foo: computed('intl.locale', function() {
+    return this.intl.t('js-translation');
+  }),
+});

--- a/fixtures/remove-unused-translations/app/templates/application.hbs
+++ b/fixtures/remove-unused-translations/app/templates/application.hbs
@@ -1,0 +1,1 @@
+{{t "hbs-translation"}}

--- a/fixtures/remove-unused-translations/translations/de.json
+++ b/fixtures/remove-unused-translations/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "hbs-translation": "Lenkstage",
+  "js-translation": "Affentheater",
+  "foo": "BARR!",
+  "extra": "drei",
+  "foo.bar.unnested": "unnested key"
+}

--- a/fixtures/remove-unused-translations/translations/en.json
+++ b/fixtures/remove-unused-translations/translations/en.json
@@ -1,0 +1,6 @@
+{
+  "hbs-translation": "HBS!",
+  "js-translation": "JS!",
+  "foo": "bar",
+  "foo.bar.unnested": "unnested key"
+}

--- a/test.js
+++ b/test.js
@@ -5,24 +5,37 @@ let fixtures = fs.readdirSync(`${__dirname}/fixtures/`);
 
 describe('Test Fixtures', () => {
   let output;
+  let writtenFiles;
   let fixturesWithErrors = ['emblem', 'missing-translations', 'unused-translations'];
+  let fixturesWithFix = ['remove-unused-translations', 'remove-unused-translations-nested'];
 
   beforeEach(() => {
     output = '';
+    writtenFiles = new Map();
   });
 
   function log(str = '') {
     output += `${str}\n`;
   }
+  function writeToFile(filePath, updatedTranslations) {
+    let fileName = filePath.split('/').slice(-2).join('/');
+    writtenFiles.set(fileName, updatedTranslations);
+  }
 
   for (let fixture of fixtures) {
     test(fixture, async () => {
-      let returnValue = await run(`${__dirname}/fixtures/${fixture}`, { log, color: false });
+      let returnValue = await run(`${__dirname}/fixtures/${fixture}`, {
+        log,
+        fix: fixturesWithFix.includes(fixture),
+        color: false,
+        writeToFile,
+      });
 
       let expectedReturnValue = fixturesWithErrors.includes(fixture) ? 1 : 0;
 
       expect(returnValue).toEqual(expectedReturnValue);
       expect(output).toMatchSnapshot();
+      expect(writtenFiles).toMatchSnapshot();
     });
   }
 });


### PR DESCRIPTION
This PR add a --fix option when running ember-intl-analyzer that should remove all unused translations whether they are whole keys or nested.

This is the first draft 

Todo:
- [ ] update documentation to show the --fix option