### PR TITLE
Add additional guard to check if at the top of the parent tree and tests

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -112,11 +112,12 @@ exports[`Test Fixtures remove-unused-translations-nested 1`] = `
 [3/4] ⚙️   Checking for unused translations...
 [4/4] ⚙️   Checking for missing translations...
 
- ⚠️   Found 3 unused translations!
+ ⚠️   Found 4 unused translations!
 
    - foo (used in de.json and en.json)
    - extra (used in de.json)
    - parent.child.unusedKey (used in de.json and en.json)
+   - unusedParent.unusedChild.unusedKey (used in de.json and en.json)
 
  👏  No missing translations were found!
 

--- a/fixtures/remove-unused-translations-nested/translations/de.json
+++ b/fixtures/remove-unused-translations-nested/translations/de.json
@@ -8,5 +8,10 @@
       "unusedKey": "unused Key",
     },
     "secondChild": "usedKey"
+  },
+  "unusedParent": {
+    "unusedChild": {
+      "unusedKey": "unused Key",
+    }
   }
 }

--- a/fixtures/remove-unused-translations-nested/translations/en.json
+++ b/fixtures/remove-unused-translations-nested/translations/en.json
@@ -7,5 +7,10 @@
       "unusedKey": "unused Key",
     },
     "secondChild": "usedKey"
+  },
+  "unusedParent": {
+    "unusedChild": {
+      "unusedKey": "unused Key",
+    }
   }
 }

--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ function deleteNestedTranslation(file, translationKey, isFullPath = false) {
   //Check if this object has another translations if not delete the key.
   if (Object.keys(translationParent[attributeKey]).length === 0 || isFullPath) {
     delete translationParent[attributeKey];
-    if (objectKeys.length) {
+    if (objectKeys.length > 0 && translationParentKeys.length > 0) {
       let parentKey = translationParentKeys.join('.');
       //continue to travel up parents to remove empty translation key objects.
       deleteNestedTranslation(file, parentKey);


### PR DESCRIPTION
This PR adds an additional guard to check if there are any translationParentKeys as if this is empty the user is at the highest level they can go which was causing the error in: #441 

Additional data was added to the nested test scenario to now catch the issue this PR solves.