### PR TITLE
Add support for translations in in-repo addons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -44,6 +44,26 @@ exports[`Test Fixtures emblem 1`] = `
 
 exports[`Test Fixtures emblem 2`] = `Map {}`;
 
+exports[`Test Fixtures in-repo-translations 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ ⚠️   Found 1 unused translations!
+     You can use --fix to remove all unused translations.
+
+   - in-repo-addon.unused (used in lib/in-repo-addon/translations/en.yaml)
+
+ ⚠️   Found 2 missing translations!
+
+   - translation-missing-in-addon (used in lib/in-repo-addon/addon/templates/addon.hbs)
+   - translation-missing-in-app (used in lib/in-repo-addon/app/templates/application.hbs)
+"
+`;
+
+exports[`Test Fixtures in-repo-translations 2`] = `Map {}`;
+
 exports[`Test Fixtures missing-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/in-repo-translations/app/controllers/application.js
+++ b/fixtures/in-repo-translations/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  get foo() {
+    return this.intl.t('js-translation');
+  }
+}

--- a/fixtures/in-repo-translations/app/templates/application.hbs
+++ b/fixtures/in-repo-translations/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{t "hbs-translation"}}
+{{t "in-repo-addon.translation-outside-addon"}}

--- a/fixtures/in-repo-translations/lib/in-repo-addon/addon/controllers/addon.js
+++ b/fixtures/in-repo-translations/lib/in-repo-addon/addon/controllers/addon.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class AddonController extends Controller {
+  get foo() {
+    return this.intl.t('in-repo-addon.addon.js-translation');
+  }
+}

--- a/fixtures/in-repo-translations/lib/in-repo-addon/addon/templates/addon.hbs
+++ b/fixtures/in-repo-translations/lib/in-repo-addon/addon/templates/addon.hbs
@@ -1,0 +1,3 @@
+{{t "in-repo-addon.addon.hbs-translation"}}
+{{t "translation-outside-app-in-addon"}}
+{{t "translation-missing-in-addon"}}

--- a/fixtures/in-repo-translations/lib/in-repo-addon/app/controllers/application.js
+++ b/fixtures/in-repo-translations/lib/in-repo-addon/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  get foo() {
+    return this.intl.t('in-repo-addon.app.js-translation');
+  }
+}

--- a/fixtures/in-repo-translations/lib/in-repo-addon/app/templates/application.hbs
+++ b/fixtures/in-repo-translations/lib/in-repo-addon/app/templates/application.hbs
@@ -1,0 +1,3 @@
+{{t "in-repo-addon.app.hbs-translation"}}
+{{t "translation-outside-app-in-app"}}
+{{t "translation-missing-in-app"}}

--- a/fixtures/in-repo-translations/lib/in-repo-addon/translations/en.yaml
+++ b/fixtures/in-repo-translations/lib/in-repo-addon/translations/en.yaml
@@ -1,0 +1,9 @@
+in-repo-addon:
+  addon:
+    hbs-translation: HBS in in-repo addon addon
+    js-translation: JS in in-repo addon addon
+  app:
+    hbs-translation: HBS in in-repo addon app
+    js-translation: JS in in-repo addon app
+  translation-outside-addon: This translation is used outside the in-repo addon
+  unused: This translation is unused

--- a/fixtures/in-repo-translations/package.json
+++ b/fixtures/in-repo-translations/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "in-repo-translations",
+  "ember-addon": {
+    "paths": [
+      "lib/in-repo-addon"
+    ]
+  }
+}

--- a/fixtures/in-repo-translations/translations/en.yaml
+++ b/fixtures/in-repo-translations/translations/en.yaml
@@ -1,0 +1,4 @@
+hbs-translation: HBS!
+js-translation: JS!
+translation-outside-app-in-addon: This translation is only used in the addon folder of the addon
+translation-outside-app-in-app: This translation is only used in the app folder of the addon

--- a/test.js
+++ b/test.js
@@ -6,7 +6,12 @@ let fixtures = fs.readdirSync(`${__dirname}/fixtures/`);
 describe('Test Fixtures', () => {
   let output;
   let writtenFiles;
-  let fixturesWithErrors = ['emblem', 'missing-translations', 'unused-translations'];
+  let fixturesWithErrors = [
+    'emblem',
+    'missing-translations',
+    'unused-translations',
+    'in-repo-translations',
+  ];
   let fixturesWithFix = ['remove-unused-translations', 'remove-unused-translations-nested'];
 
   beforeEach(() => {


### PR DESCRIPTION
In our codebase I tried out this addon and I realized that in-repo addons were not supported yet (already [issued](https://github.com/simplabs/ember-intl-analyzer/issues/5) a while ago). It seemed easy to add though, so I gave it a try to get it working for us at least. I got it to work, but before I look into adding tests, let me know if this is a good approach and if maybe more use cases with in-repo addons should be supported.

~Note: I don't know if running the tests needs to be explicitly allowed because this is my first PR here, but locally the tests still pass at least.~ I added a test already as I was curious how the tests worked, so now there is proof it works :)