### PR TITLE
Add support for translations in actual addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Include node modules used in tests
+!fixtures/**/node_modules
+
 # TypeScript v1 declaration files
 typings/
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ To prevent that from happening you can configure a `whitelist`, which accepts an
 array of regular expressions that will be checked when looking for unused
 translations.
 
+### `externalPaths`
+
+If your application uses translations provided by (external) addons, then those
+translations will show up as missing by default. In order to include such translations,
+you can define `externalPaths` in the configuration file as follows:
+
+```js
+export default {
+  externalPaths: ['my-addon'],
+};
+```
+
+This example will try to find translation files in `node_modules/my-addon/translations`.
+Patterns supported by [`globby`](https://www.npmjs.com/package/globby) are also
+possible here, e.g. this:
+```js
+externalPaths: ['@*/*']
+```
+will look up translations in scoped addons like `node_modules/@company/scoped-addon/translations`.
+
 ### `--fix`
 If your application has a lot of unused translations you can run the command with
 the `--fix` to remove them. Remember to double check your translations as dynamic

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -44,6 +44,22 @@ exports[`Test Fixtures emblem 1`] = `
 
 exports[`Test Fixtures emblem 2`] = `Map {}`;
 
+exports[`Test Fixtures external-addon-translations 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ ⚠️   Found 1 missing translations!
+
+   - other-external-addon.used-by-app-translation (used in app/templates/application.hbs)
+"
+`;
+
+exports[`Test Fixtures external-addon-translations 2`] = `Map {}`;
+
 exports[`Test Fixtures in-repo-translations 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/external-addon-translations/app/controllers/application.js
+++ b/fixtures/external-addon-translations/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  get foo() {
+    return this.intl.t('js-translation');
+  }
+}

--- a/fixtures/external-addon-translations/app/templates/application.hbs
+++ b/fixtures/external-addon-translations/app/templates/application.hbs
@@ -1,0 +1,4 @@
+{{t "hbs-translation"}}
+{{t "external-addon.used-by-app-translation"}}
+{{t "other-external-addon.used-by-app-translation"}}
+{{t "company.scoped-addon.used-by-app-translation"}}

--- a/fixtures/external-addon-translations/node_modules/@company/scoped-addon/templates/application.hbs
+++ b/fixtures/external-addon-translations/node_modules/@company/scoped-addon/templates/application.hbs
@@ -1,0 +1,1 @@
+{{t "scoped-addon.missing.but.unmarked-translation"}}

--- a/fixtures/external-addon-translations/node_modules/@company/scoped-addon/translations/en.yaml
+++ b/fixtures/external-addon-translations/node_modules/@company/scoped-addon/translations/en.yaml
@@ -1,0 +1,4 @@
+company:
+  scoped-addon:
+    used-by-app-translation: This translation is used by app, and is not marked missing
+    unused-by-app-translation: This translation is not used by app, but is not marked unused, because it's external

--- a/fixtures/external-addon-translations/node_modules/external-addon/templates/application.hbs
+++ b/fixtures/external-addon-translations/node_modules/external-addon/templates/application.hbs
@@ -1,0 +1,1 @@
+{{t "external-addon.missing.but.unmarked-translation"}}

--- a/fixtures/external-addon-translations/node_modules/external-addon/translations/en.yaml
+++ b/fixtures/external-addon-translations/node_modules/external-addon/translations/en.yaml
@@ -1,0 +1,3 @@
+external-addon:
+  used-by-app-translation: This translation is used by app, and is not marked missing
+  unused-by-app-translation: This translation is not used by app, but is not marked unused, because it's external

--- a/fixtures/external-addon-translations/node_modules/other-external-addon/translations/en.yaml
+++ b/fixtures/external-addon-translations/node_modules/other-external-addon/translations/en.yaml
@@ -1,0 +1,2 @@
+other-external-addon:
+  used-by-app-translation: This translation is used by app, but not included in the config

--- a/fixtures/external-addon-translations/translations/en.yaml
+++ b/fixtures/external-addon-translations/translations/en.yaml
@@ -1,0 +1,2 @@
+hbs-translation: HBS!
+js-translation: JS!

--- a/test.js
+++ b/test.js
@@ -11,8 +11,14 @@ describe('Test Fixtures', () => {
     'missing-translations',
     'unused-translations',
     'in-repo-translations',
+    'external-addon-translations',
   ];
   let fixturesWithFix = ['remove-unused-translations', 'remove-unused-translations-nested'];
+  let fixturesWithConfig = {
+    'external-addon-translations': {
+      externalPaths: ['@*/*', 'external-addon'],
+    },
+  };
 
   beforeEach(() => {
     output = '';
@@ -34,6 +40,7 @@ describe('Test Fixtures', () => {
         fix: fixturesWithFix.includes(fixture),
         color: false,
         writeToFile,
+        config: fixturesWithConfig[fixture],
       });
 
       let expectedReturnValue = fixturesWithErrors.includes(fixture) ? 1 : 0;


### PR DESCRIPTION
Similar to #480, but this PR adds support for actual addons, also issued in #5 (and closes #5). Not too sure if this covers all scenarios (I just looked up `translations` folders in `node_modules/*` and `node_modules/@*/*`, the latter for scoped addons), but at least it works for our codebase.

To elaborate a bit: translations in actual addons are available for use in an app, but since they're not owned by the app, they show up under `Missing translations` (the ones that are used). Just adding them to the `translationFiles` won't work properly yet, as that would cause such translations to end up under `Unused translations` while they could still be used by the addon itself (and that's not the purpose here). So, I split it up into own translations and addon translations, so that just the own translations can be used to detect unused translations, and the maps combined to detect missing translations.

~Note that I didn't add tests yet, I'd first like to have some confirmation that this a good approach.~ After I added a test for in-repo addons, it was quite simple to add a test for actual addons as well.