### PR TITLE
Add support for concat expressions in HBS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ To prevent that from happening you can configure a `whitelist`, which accepts an
 array of regular expressions that will be checked when looking for unused
 translations.
 
+### `analyzeConcatExpression`
+
+If your template contains translations like this:
+```hbs
+{{t (concat "actions." (if @isEditing "save" "publish"))}}
+```
+then ember-intl-analyzer does not detect that `actions.save` and `actions.publish`
+are in fact used translations, so they can be incorrectly flagged as missing or
+unused. As the `concat` helper can make it harder to read, it's encouraged to
+rewrite it to for example:
+```hbs
+{{if @isEditing (t "actions.save") (t "actions.publish")}}
+```
+
+However, if your application relies heavily on this `concat` helper, then rewriting
+may not be the best option for you. In that case, you can opt-in to analyze `concat`
+expressions too by setting the `analyzeConcatExpression` flag in the configuration file:
+
+```js
+export default {
+  analyzeConcatExpression: true,
+};
+```
+
 ### `externalPaths`
 
 If your application uses translations provided by (external) addons, then those

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test Fixtures concat-expression 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ ⚠️   Found 2 missing translations!
+
+   - prefix.simple-but-missing (used in app/templates/application.hbs)
+   - prefix.key-that-should-exist-but-is-missing.value (used in app/templates/application.hbs)
+"
+`;
+
+exports[`Test Fixtures concat-expression 2`] = `Map {}`;
+
 exports[`Test Fixtures decorators 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/concat-expression/app/templates/application.hbs
+++ b/fixtures/concat-expression/app/templates/application.hbs
@@ -1,0 +1,10 @@
+{{t (concat "prefix" "." "simple")}}
+{{t (concat "prefix" "." "simple-but-missing")}}
+{{t (concat "prefix." (if true "with-if-first" "with-if-second"))}}
+{{t (concat "prefix.some-action" (if this.isCompact "-short"))}}
+{{t (concat "prefix." (if this.isEditing "edit" "new") ".label")}}
+{{t (if true "foo" (concat "prefix." (if this.isEditing "edit" "new") ".nested"))}}
+{{t (concat "prefix." this.dynamicKey ".not-missing")}}
+{{t (concat "prefix." (if true "a1" (if false "b1" (concat "c" (if false "1" "2")))) ".value")}}
+{{t (concat "prefix." (if true this.dynamicKey "key-that-should-exist") ".value")}}
+{{t (concat "prefix." (if true this.dynamicKey "key-that-should-exist-but-is-missing") ".value")}}

--- a/fixtures/concat-expression/translations/en.yaml
+++ b/fixtures/concat-expression/translations/en.yaml
@@ -1,0 +1,23 @@
+prefix:
+  simple: Simple concatenation
+  with-if-first: First condition
+  with-if-second: Second condition
+  some-action: Action that can be long
+  some-action-short: Action
+  edit:
+    label: Label on edit branch
+    nested: Nested concat on edit branch
+  new:
+    label: Label on new branch
+    nested: Nested concat on new branch
+  a1:
+    value: Value
+  b1:
+    value: Value
+  c1:
+    value: Value
+  c2:
+    value: Value
+  key-that-should-exist:
+    value: value
+foo: Foo

--- a/fixtures/no-issues/app/templates/application.hbs
+++ b/fixtures/no-issues/app/templates/application.hbs
@@ -1,1 +1,2 @@
 {{t "hbs-translation"}}
+{{t (concat "concat-" "expression.is-skipped")}}

--- a/test.js
+++ b/test.js
@@ -12,8 +12,10 @@ describe('Test Fixtures', () => {
     'unused-translations',
     'in-repo-translations',
     'external-addon-translations',
+    'concat-expression',
   ];
   let fixturesWithFix = ['remove-unused-translations', 'remove-unused-translations-nested'];
+  let fixturesWithConcat = ['concat-expression'];
   let fixturesWithConfig = {
     'external-addon-translations': {
       externalPaths: ['@*/*', 'external-addon'],
@@ -41,6 +43,7 @@ describe('Test Fixtures', () => {
         color: false,
         writeToFile,
         config: fixturesWithConfig[fixture],
+        analyzeConcatExpression: fixturesWithConcat.includes(fixture),
       });
 
       let expectedReturnValue = fixturesWithErrors.includes(fixture) ? 1 : 0;


### PR DESCRIPTION
After adding support for (in-repo) addons, I noticed that dynamically constructed translations were not recognized. In HBS files this is usually done with the `concat` helper, which is often just a combination of strings literals and if expressions (e.g. `{{t (concat "actions." (if @isEditing "save" "publish"))}}`), and this PR adds support for that.

Note that like my 2 other PRs, I haven't added ~tests or~ (self-review) comments yet, I'll do that when this gets a chance of being actually merged. Edit: I added tests that contain some examples of what this PR actually adds support for.