### PR TITLE
Add .editorconfig file for more consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
When I was adding fixture files for tests, I noticed that my editor didn't automatically insert newlines anymore, so I added the `.editorconfig` that configures this.