### PR TITLE
Add support to specify which translation files are analyzed

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ externalPaths: ['@*/*']
 ```
 will look up translations in scoped addons like `node_modules/@company/scoped-addon/translations`.
 
+### `translationFiles`
+
+By default, this addon will try to find missing and unused translations in any YAML or
+JSON file within the `translations` folders of your application (`['**/*.json', '**/*.yaml', '**/*.yml']`).
+However, if you would like to only analyze a subset of translation files, you can override
+`translationFiles` in the configuration file as follows:
+
+```js
+export default {
+  translationFiles: ['**/en.yaml'],
+};
+```
+
+This example will try to find all `en.yaml` files in the different `translations`
+folders, but any patterns supported by [`globby`](https://www.npmjs.com/package/globby) are also
+possible here.
+
 ### `--fix`
 If your application has a lot of unused translations you can run the command with
 the `--fix` to remove them. Remember to double check your translations as dynamic

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test Fixtures chosen-translations 1`] = `
+"[1/4] 🔍  Finding JS and HBS files...
+[2/4] 🔍  Searching for translations keys in JS and HBS files...
+[3/4] ⚙️   Checking for unused translations...
+[4/4] ⚙️   Checking for missing translations...
+
+ 👏  No unused translations were found!
+
+ ⚠️   Found 1 missing translations!
+
+   - only-nl-translation (used in app/controllers/application.js)
+"
+`;
+
+exports[`Test Fixtures chosen-translations 2`] = `Map {}`;
+
 exports[`Test Fixtures concat-expression 1`] = `
 "[1/4] 🔍  Finding JS and HBS files...
 [2/4] 🔍  Searching for translations keys in JS and HBS files...

--- a/fixtures/chosen-translations/app/controllers/application.js
+++ b/fixtures/chosen-translations/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  foo() {
+    return this.intl.t('only-nl-translation');
+  }
+}

--- a/fixtures/chosen-translations/app/templates/application.hbs
+++ b/fixtures/chosen-translations/app/templates/application.hbs
@@ -1,0 +1,1 @@
+{{t "present-translation"}}

--- a/fixtures/chosen-translations/translations/en.yaml
+++ b/fixtures/chosen-translations/translations/en.yaml
@@ -1,0 +1,1 @@
+present-translation: This is present in both

--- a/fixtures/chosen-translations/translations/nl.yaml
+++ b/fixtures/chosen-translations/translations/nl.yaml
@@ -1,0 +1,3 @@
+only-nl-translation: This translation is not there in EN, so should be considered missing when only filtering on EN
+present-translation: This is present in both
+unused-translation: This translation is only in NL and unused, but should not be considered as such when only filtering on EN

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function run(rootDir, options = {}) {
 
   log(`${step(3)} ⚙️   Checking for unused translations...`);
 
-  let ownTranslationFiles = await findOwnTranslationFiles(rootDir);
+  let ownTranslationFiles = await findOwnTranslationFiles(rootDir, config);
   let externalTranslationFiles = await findExternalTranslationFiles(rootDir, config);
   let existingOwnTranslationKeys = await analyzeTranslationFiles(rootDir, ownTranslationFiles);
   let existingExternalTranslationKeys = await analyzeTranslationFiles(
@@ -124,8 +124,8 @@ async function findInRepoFiles(cwd) {
   return globby(joinPaths(inRepoFolders, ['**/*.js', '**/*.hbs', '**/*.emblem']), { cwd });
 }
 
-async function findOwnTranslationFiles(cwd) {
-  return findTranslationFiles(cwd, ['', ...findInRepoPaths(cwd)]);
+async function findOwnTranslationFiles(cwd, config) {
+  return findTranslationFiles(cwd, ['', ...findInRepoPaths(cwd)], config);
 }
 
 async function findExternalTranslationFiles(cwd, config) {
@@ -133,15 +133,18 @@ async function findExternalTranslationFiles(cwd, config) {
     return [];
   }
 
-  return findTranslationFiles(cwd, joinPaths('node_modules', config.externalPaths));
+  return findTranslationFiles(cwd, joinPaths('node_modules', config.externalPaths), config);
 }
 
-async function findTranslationFiles(cwd, inputFolders) {
+async function findTranslationFiles(cwd, inputFolders, config) {
   let translationPaths = joinPaths(inputFolders, ['translations']);
 
-  return globby(joinPaths(translationPaths, ['**/*.json', '**/*.yaml', '**/*.yml']), {
-    cwd,
-  });
+  return globby(
+    joinPaths(translationPaths, config.translationFiles || ['**/*.json', '**/*.yaml', '**/*.yml']),
+    {
+      cwd,
+    }
+  );
 }
 
 function findInRepoPaths(cwd) {

--- a/test.js
+++ b/test.js
@@ -13,12 +13,16 @@ describe('Test Fixtures', () => {
     'in-repo-translations',
     'external-addon-translations',
     'concat-expression',
+    'chosen-translations',
   ];
   let fixturesWithFix = ['remove-unused-translations', 'remove-unused-translations-nested'];
   let fixturesWithConcat = ['concat-expression'];
   let fixturesWithConfig = {
     'external-addon-translations': {
       externalPaths: ['@*/*', 'external-addon'],
+    },
+    'chosen-translations': {
+      translationFiles: ['**/en.yaml'],
     },
   };
 


### PR DESCRIPTION
In our application we have English translations as a base language and all other languages are maintained externally on Phrase (so that those translations do not rely on developers speaking the language). When English translations are added or removed, they are pushed to Phrase, where they are added to or removed from the other languages, and then those changes are pulled back into the source code again. However, we recently ran into a problem with that workflow when we tried to remove an English translation, because this addon marked that translation as unused in the other languages. Although this is not incorrect (it is in fact unused), we don't want to remove those translations manually, but instead remove them from Phrase which removes them from the source code when they're pulled in (which is a separate step in our development process).
A similar issue occurs when an English translation is removed by accident, with the translation still being present in the other languages. Then that translation is not seen as missing, because it's still there in the other languages.

Long story short, it would really help if we can configure which translation files are analyzed. Because of these issues we've removed this analyze step from our CI workflow to prevent developers having a failing build when we don't want to.

In our case the config value of `translationFiles` would be conditional, so something like `process.env.ONLY_ANALYZE_EN_TRANSLATIONS ? ['**/en-us.yaml'] : null`, but that felt too specific to include in the readme.